### PR TITLE
Expand personas and update process docs to address issue #4

### DIFF
--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -75,6 +75,107 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
+## UX Designer
+
+### Role Summary
+Designs user interfaces, workflows, and experiences, advocating for user needs and accessibility. Collaborates with Product Manager to refine requirements and Developers/QA to ensure feasibility and test coverage.
+
+### Responsibilities
+- Create wireframes, prototypes, and user flows
+- Conduct user research and usability testing
+- Validate acceptance of user-facing features
+- Document design decisions
+
+### Goals
+- Deliver intuitive, accessible, and engaging user experiences
+- Ensure solutions meet usability and accessibility standards
+
+### Typical Communication
+- Regular feedback sessions with Product Manager and Developers
+- Design reviews and user testing reports
+
+---
+
+## Business Analyst
+
+### Role Summary
+Acts as the link between business goals and technical implementation. Collects and analyzes requirements, clarifies ambiguity, and documents acceptance criteria.
+
+### Responsibilities
+- Gather and prioritize business and user requirements
+- Translate requirements to actionable backlog items
+- Support Product Manager in defining success criteria
+
+### Goals
+- Ensure requirements are clearly defined and actionable
+- Eliminate ambiguity between business and technical teams
+
+### Typical Communication
+- Requirement gathering workshops
+- User stories/backlog refinement meetings
+
+---
+
+## DevOps Engineer
+
+### Role Summary
+Owns build, deployment, and release automation, ensuring reliability and repeatability across environments.
+
+### Responsibilities
+- Maintain CI/CD pipelines and deployment scripts
+- Implement monitoring and alerting
+- Validate build quality before release
+
+### Goals
+- Enable frictionless and reliable deployments
+- Reduce downtime and release risk
+
+### Typical Communication
+- Status updates in release meetings
+- Coordination with Developers and QA during deployment
+
+---
+
+## Customer Support Lead
+
+### Role Summary
+Advocates for customer needs and provides crucial feedback on release readiness and incident impact.
+
+### Responsibilities
+- Communicate deployment and incident updates to users
+- Gather feedback and report post-release issues
+- Ensure documentation supports customer needs
+
+### Goals
+- Shorten the time to resolve customer issues
+- Enable customer success through clear documentation and communication
+
+### Typical Communication
+- Regular syncs with PM and Developers
+- Customer feedback summaries
+
+---
+
+## Security Lead
+
+### Role Summary
+Champions secure development and operational practices, and coordinates incident response for security events.
+
+### Responsibilities
+- Assess and mitigate product risks
+- Lead security reviews and runbooks
+- Coordinate incident investigations
+
+### Goals
+- Ensure compliance and reduce security risks
+- Improve security posture proactively
+
+### Typical Communication
+- Security review updates
+- Incident and remediation reports
+
+---
+
 ## How these personas are used in the exercise
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.


### PR DESCRIPTION
- Adds new personas to `docs/octoacme-roles-and-personas.md` (UX Designer, Business Analyst, DevOps Engineer, Customer Support Lead, Security Lead)
- Clarifies how these roles interact with existing roles
- Updates related checklists/templates as needed
- Addresses improvements discussed in issue #4 

cc @KimKellerRasmussen